### PR TITLE
Update README & documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,46 @@
 <p align="center"><img src="help/logo/logo_official.png"></p>
 
-# [what is kubeojo in 10sec](help/README.md)
+# ["What is kubeojo?" in 10 seconds](help/README.md)
 
-# Developing kubeojo:
+# Developing kubeojo
 
-[devel-setup](kubeojo/README.md)
+See [devel-setup](kubeojo/README.md)
 
 # How to run kubeojo
 
-At this point kubeojo is under the dev. phase not 1.0 version, as soon a version is ready i will update the doc for running kubeojo.
-( you can still pick up issues from GitHub if you want to contribute for 1.0 version) 
+At this point kubeojo is under active development and has not yet reached version 1.0. As soon as a stable version is ready, the docs will be updated to describe how to run kubeojo.
+( Please feel free to pick up issues from GitHub if you want to contribute for version 1.0) 
 
 # What is kubeojo?
 
-Each project nowdays have a testsuite that is running on CI for ensure it stability.
+Nowadays, it is extremely common that projects have a test suite running on CI system to ensure the project's stability.
 
-When having big testsuites, there are always "brittle tests", tests that fail like 1 time on 10 Runs.
+When test suites get big, it is very often the case that there are "brittle tests" in the suite. These are the kinds of tests that typically run just fine, but randomly fail from time to time (such as once every 10 runs or so).
 
-Kubeojo examine methodically and in detail your tests failures:
-storing the results and  visualizing the "brittle tests" help to detect this tests and fix them.
-
-Kubeojo will track and visualize this tests with phoenix and D3.js.
+Kubeojo methodically examines your tests failures. It stores the results and visualizes the "brittle tests" to help detect and fix them. The UI of kubeojo is powered by Phoenix 1.3 and D3.js.
 
 
 # Configuration:
 
-In order to use kubeojo, you need to have 2 yaml files configured.
+In order to use kubeojo, you need to have 2 YAML files configured:
 
-1) Jenkins credentials.
+1) Jenkins credentials:
 `kubeojo/kubeojo/config/jenkins_credentials.yml`
 
-as password you can use the a Jenkins Token.
+as password you can use the a Jenkins Token:
 ```yaml
 jenkins_url: "https://i_love_opensuse.ci.com/"
 username: "Jenkins_username"
 password: "2faidfakjfdkjadf30ff"
 ```
 
-2) Jenkins Jobs you want to analyze.
+2) Jenkins Jobs you want to analyze:
 
 `kubeojo/kubeojo/config/jenkins_jobs.yml`
 
-Insert here the jobs name you want to analyze the tests-results.
+Here you should insert the name of the jobs you want to analyze the tests results for.
 
-**Important**: your jobs need to export tests in **junit-format**, so that kubeojo can fetch the junit_results.
+**Important**: your jobs need to export tests in **junit-format** to ensure kubeojo can fetch the junit_results.
 
 ```ỳaml
 jenkins_jobs: ["manager-3.1-cucumber", "manager-Head-cucumber"]
@@ -56,9 +53,6 @@ https://github.com/MalloZup/kubeojo/issues
 # Contributors:
 
 Thanks to all [contributors](https://github.com/MalloZup/kubeojo/graphs/contributors) for kubeojo! 
-
-# Releasing:
-(relasing)[help/relasing.md]
 
 
 <p align="center"><img src="help/logo/logo_small_official.png"></p>

--- a/help/README.md
+++ b/help/README.md
@@ -1,22 +1,21 @@
-# Kubeojo explained live!
+# Kubeojo explained
 
 ## Let's have a look:
 
-The balls represent test-failures over a period of time. 
+The balls represent test failures over a period of time. 
 
-A big ball is something that is fragile in your product/software.
-It can be a weakness on tests-automation or a bug affecting your software.
+A big ball is something that is fragile in your product/software. It can be a weakness in your automated tests, or a bug affecting your software.
 
-Kubeojo index page give you a list of wich job you want to keep track
+The index page presents a list of jobs that kubeojo is tracking for you
 
 ![global](global.png)
 
-# How looks like a bubble chart  from kubeojo
+# A bubble chart visualized by kubeojo
 
 ![zoom1](zoom.png)
 
-### Balls are changing all the time.
+### Balls are changing all the time
 
-Since kubeojo will fetch testsresults overtime, the size of the balls will increase if a tests fails.
+Since kubeojo will fetch test results over time, the size of the balls will increase as tests fail.
 
 ![zoom2l](zoom2.png)

--- a/kubeojo/README.md
+++ b/kubeojo/README.md
@@ -2,16 +2,16 @@
 
 # Elixir setup 
 
-Kubeojo is based on elixir and phoenix frameworks.
+Kubeojo is built with Elixir and the Phoenix framework.
 
-* [Install elixir](https://elixir-lang.org/install.html)
+* [Install Elixir](https://elixir-lang.org/install.html)
 
-* [configuration](https://github.com/MalloZup/kubeojo#configuration)
-   you need to configure jenkins user and jobs to be fetched.
+* [Configuration](https://github.com/MalloZup/kubeojo#configuration)
+   - you need to configure a Jenkins user and the jobs to be fetched.
 
 ## Phoenix setup
 
-You need to have postgres installed in order to develop with phoenix.
+You need to have Postgres installed in order to develop with Phoenix.
 
 
 To start your Phoenix app:
@@ -20,23 +20,21 @@ To start your Phoenix app:
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
   
 
-## Full the database with Jenkins jobs data
+## Fill the database with Jenkins jobs data
 
-Atm you need to do :
-
-this will open a elixir shell
+Open a Elixir shell:
 ```elixir
 
 /bin/kubeojo/kubeojo$ iex -S mix
 ```
 
-execute the function to put data in db
+Execute the function to put data in the database:
 ```elixir
 Kubeojo.Jenkins.write_tests_failures_to_db
 
 ```
 
-## starting the web-framework
+## Starting the web framework
 
 * Start Phoenix endpoint with `mix phoenix.server`
 * Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.


### PR DESCRIPTION
This commit addesses some typos and grammatical adjustments, and removes the (currently completely missing) reference to release documentation.

Done to address some issues highlighted by https://github.com/MalloZup/kubeojo/issues/20


